### PR TITLE
Now able to send data from ESP32 to Android app

### DIFF
--- a/android_app/app/src/main/java/com/sinric/esp32_android_app/BluetoothLeService.java
+++ b/android_app/app/src/main/java/com/sinric/esp32_android_app/BluetoothLeService.java
@@ -194,6 +194,10 @@ public class BluetoothLeService extends Service {
                     mNotifyCharacteristic = gattCharacteristic;
                     mBluetoothGatt.setCharacteristicNotification(gattCharacteristic, true);
                     Log.i("BluetoothLeService","setCharacteristicNotification : " + uuid);
+                    UUID magic_uuid = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
+                    BluetoothGattDescriptor descriptor = gattCharacteristic.getDescriptor(magic_uuid);
+                    descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
+                    mBluetoothGatt.writeDescriptor(descriptor);
                 }
             }
         }

--- a/android_app/app/src/main/java/com/sinric/esp32_android_app/MainActivity.java
+++ b/android_app/app/src/main/java/com/sinric/esp32_android_app/MainActivity.java
@@ -239,10 +239,11 @@ public class MainActivity extends AppCompatActivity implements  OnBluetoothDevic
             if (data != null && data.length > 0) {
                 final StringBuilder stringBuilder = new StringBuilder(data.length);
                 for (byte byteChar : data) {
-                    stringBuilder.append(String.format("%02X ", byteChar));
+                    char b = (char) byteChar;
+                    stringBuilder.append(b);
                 }
 
-                Log.i("MainActivity","Get string(ASCII) : " + stringBuilder.toString());
+                Log.i("MainActivity","Get string : " + stringBuilder.toString());
             }
         }
         }

--- a/bluetooth_android_esp32/src/main.cpp
+++ b/bluetooth_android_esp32/src/main.cpp
@@ -82,11 +82,13 @@ void setup() {
 
 void loop() {
     // notify changed value
-    if (deviceConnected) {
-        //pCharacteristic->setValue(&value, 1);
-        //pCharacteristic->notify();
-       // value++;
-       // delay(10); // bluetooth stack will go into congestion, if too many packets are sent
+	if (deviceConnected) {
+        Serial.println("send bluetooth..");
+        String s = "notification string";
+        pCharacteristic->setValue(s.c_str());
+        pCharacteristic->notify();
+        value++;
+        delay(2000); // bluetooth stack will go into congestion, if too many packets are sent
     }
     // disconnecting
     if (!deviceConnected && oldDeviceConnected) {


### PR DESCRIPTION
With the repo you were not able to send data from ESP32 to Android App, due to a permission issue in the BLE descriptor.

I fixed following this SOF https://stackoverflow.com/questions/27068673/subscribe-to-a-ble-gatt-notification-android

As you can see in the image attached now you can notify the client from the server (e.g. ESP32 -> Android)

![Screenshot 2021-04-17 at 03 18 45](https://user-images.githubusercontent.com/20618047/115099250-a6c15e80-9f2c-11eb-9967-a2f788efb2a0.png)

![Screenshot 2021-04-17 at 03 28 39](https://user-images.githubusercontent.com/20618047/115099302-015aba80-9f2d-11eb-9d10-f7dda740e019.png)
